### PR TITLE
feat: add favorable-move (MFE) primitives to chart_trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `cargo audit` CI job using a native `cargo install cargo-audit --locked` step (no third-party Action). The job runs `cargo generate-lockfile` first since `Cargo.lock` is gitignored.
 - Added `.github/dependabot.yml` for monthly `github-actions` ecosystem updates.
 - Added `#![forbid(unsafe_code)]` at the crate root in `src/lib.rs`.
+- Added `chart_trends::peak_favorable_move` and `chart_trends::valley_favorable_move`: the per-target maximum favorable excursion (MFE) over a forward window of `period` bars after a reference index. Peak measures the entry-to-window-minimum drop; valley measures the window-maximum-minus-entry rise. Returns the raw signed `f64` (not floored at zero) and is generic over the series — the library stays policy-free. Reuses `basic_indicators::single::{min, max}` and validates via a shared underflow-safe window guard reusing `EmptyData` / `InvalidPeriod`.
 
 ### Fixed
 - README Quick Start example now compiles. Previously, `let ma = moving_average::single::moving_average(...)` followed by `println!("...: {}", ma)` was invalid because `ma: Result<f64, _>` does not implement `Display`. The example now `.unwrap()`s the `Result` and the `use` line imports `MovingAverageType` directly.

--- a/src/chart_trends.rs
+++ b/src/chart_trends.rs
@@ -16,8 +16,10 @@
 //! ## Included Functions
 //! - [`break_down_trends`]: Segments the chart into distinct up/down trends
 //! - [`overall_trend`]: Returns the overall trend (slope) for all price points
+//! - [`peak_favorable_move`]: Maximum favorable excursion (MFE) — the largest drop after a point over a forward window
 //! - [`peak_trend`]: Calculates the trend based on local peaks
 //! - [`peaks`]: Finds all local maxima (peaks) in the series
+//! - [`valley_favorable_move`]: Maximum favorable excursion (MFE) — the largest rise after a point over a forward window
 //! - [`valley_trend`]: Calculates the trend based on local valleys
 //! - [`valleys`]: Finds all local minima (valleys) in the series
 //!
@@ -204,6 +206,132 @@ pub fn valleys(
         }
     }
     Ok(valleys)
+}
+
+/// Calculates the peak favorable move (maximum favorable excursion, MFE) at a point.
+///
+/// Measures the largest downward move available in the `period` bars *after*
+/// `index`: the reference value minus the minimum of the forward window. This is
+/// the per-target magnitude that peak-based detection scores against; the library
+/// applies no policy — targets are not dropped and the result is not floored.
+///
+/// # Arguments
+///
+/// * `prices` - Slice of prices (any series; not restricted to closes)
+/// * `index` - Index of the reference bar; the move is measured from `prices[index]`
+/// * `period` - Forward window length: the number of bars after `index` to scan
+///
+/// # Returns
+///
+/// The raw signed move `prices[index] - min(prices[index + 1 ..= index + period])`.
+/// A point with no favorable (downward) move yields a value `<= 0`; flooring is
+/// the caller's responsibility, not the library's.
+///
+/// # Errors
+///
+/// Returns `TechnicalIndicatorError::EmptyData` if `prices` is empty, or
+/// `TechnicalIndicatorError::InvalidPeriod` if `period` == 0 or the forward window
+/// `index + period` runs past the end of `prices`.
+///
+/// # Examples
+///
+/// ```rust
+/// // window [104.0, 100.0, 102.0], min 100.0 -> 107.0 - 100.0 = 7.0
+/// let mfe = centaur_technical_indicators::chart_trends::peak_favorable_move(&[107.0, 104.0, 100.0, 102.0], 0, 3).unwrap();
+/// assert_eq!(mfe, 7.0);
+///
+/// // no drop: window [101.0, 102.0, 103.0], min 101.0 -> 100.0 - 101.0 = -1.0 (returned, not floored)
+/// let mfe = centaur_technical_indicators::chart_trends::peak_favorable_move(&[100.0, 101.0, 102.0, 103.0], 0, 3).unwrap();
+/// assert_eq!(mfe, -1.0);
+///
+/// // forward window runs past the end -> error
+/// assert!(centaur_technical_indicators::chart_trends::peak_favorable_move(&[100.0, 101.0, 102.0], 1, 3).is_err());
+/// ```
+pub fn peak_favorable_move(prices: &[f64], index: usize, period: usize) -> crate::Result<f64> {
+    assert_favorable_window(prices, index, period)?;
+    let window = &prices[index + 1..=index + period];
+    let trough = min(window)?;
+    Ok(prices[index] - trough)
+}
+
+/// Calculates the valley favorable move (maximum favorable excursion, MFE) at a point.
+///
+/// Measures the largest upward move available in the `period` bars *after*
+/// `index`: the maximum of the forward window minus the reference value. This is
+/// the per-target magnitude that valley-based detection scores against; the library
+/// applies no policy — targets are not dropped and the result is not floored.
+///
+/// # Arguments
+///
+/// * `prices` - Slice of prices (any series; not restricted to closes)
+/// * `index` - Index of the reference bar; the move is measured from `prices[index]`
+/// * `period` - Forward window length: the number of bars after `index` to scan
+///
+/// # Returns
+///
+/// The raw signed move `max(prices[index + 1 ..= index + period]) - prices[index]`.
+/// A point with no favorable (upward) move yields a value `<= 0`; flooring is
+/// the caller's responsibility, not the library's.
+///
+/// # Errors
+///
+/// Returns `TechnicalIndicatorError::EmptyData` if `prices` is empty, or
+/// `TechnicalIndicatorError::InvalidPeriod` if `period` == 0 or the forward window
+/// `index + period` runs past the end of `prices`.
+///
+/// # Examples
+///
+/// ```rust
+/// // window [102.0, 107.0, 104.0], max 107.0 -> 107.0 - 100.0 = 7.0
+/// let mfe = centaur_technical_indicators::chart_trends::valley_favorable_move(&[100.0, 102.0, 107.0, 104.0, 100.0], 0, 3).unwrap();
+/// assert_eq!(mfe, 7.0);
+///
+/// // no rise: window [104.0, 103.0, 102.0], max 104.0 -> 104.0 - 105.0 = -1.0 (returned, not floored)
+/// let mfe = centaur_technical_indicators::chart_trends::valley_favorable_move(&[105.0, 104.0, 103.0, 102.0], 0, 3).unwrap();
+/// assert_eq!(mfe, -1.0);
+///
+/// // forward window runs past the end -> error
+/// assert!(centaur_technical_indicators::chart_trends::valley_favorable_move(&[100.0, 101.0, 102.0], 1, 3).is_err());
+/// ```
+pub fn valley_favorable_move(prices: &[f64], index: usize, period: usize) -> crate::Result<f64> {
+    assert_favorable_window(prices, index, period)?;
+    let window = &prices[index + 1..=index + period];
+    let peak = max(window)?;
+    Ok(peak - prices[index])
+}
+
+/// Validates inputs for the favorable-move functions.
+///
+/// Errors, in order, on empty `prices`, `period` == 0, or a forward window
+/// `prices[index + 1 ..= index + period]` that runs past the end of `prices`.
+/// Underflow-safe: no subtraction, and `index + period` is checked with
+/// `checked_add`.
+fn assert_favorable_window(prices: &[f64], index: usize, period: usize) -> crate::Result<()> {
+    assert_non_empty("prices", prices)?;
+    let data_len = prices.len();
+    if period == 0 {
+        return Err(crate::TechnicalIndicatorError::InvalidPeriod {
+            period,
+            data_len,
+            reason: "must be greater than 0".to_string(),
+        });
+    }
+    // The forward window prices[index + 1 ..= index + period] is in bounds only
+    // when index + period < data_len. Use checked_add so a huge index can't wrap.
+    let past_end = match index.checked_add(period) {
+        Some(end) => end >= data_len,
+        None => true,
+    };
+    if past_end {
+        return Err(crate::TechnicalIndicatorError::InvalidPeriod {
+            period,
+            data_len,
+            reason: format!(
+                "forward window of {period} bars after index {index} runs past the data"
+            ),
+        });
+    }
+    Ok(())
 }
 
 /// OLS simple linear regression function
@@ -660,5 +788,109 @@ mod tests {
             ],
             trend_break_down
         );
+    }
+
+    #[test]
+    fn peak_favorable_move_basic_downward() {
+        // window [104.0, 100.0, 102.0], min 100.0 -> 107.0 - 100.0 = 7.0
+        let prices = vec![107.0, 104.0, 100.0, 102.0];
+        assert_eq!(7.0, peak_favorable_move(&prices, 0, 3).unwrap());
+    }
+
+    #[test]
+    fn valley_favorable_move_basic_upward() {
+        // window [102.0, 107.0, 104.0], max 107.0 -> 107.0 - 100.0 = 7.0
+        let prices = vec![100.0, 102.0, 107.0, 104.0, 100.0];
+        assert_eq!(7.0, valley_favorable_move(&prices, 0, 3).unwrap());
+    }
+
+    #[test]
+    fn peak_favorable_move_nonpositive_when_no_drop() {
+        // window [101.0, 102.0, 103.0], min 101.0 -> 100.0 - 101.0 = -1.0 (returned, not floored)
+        let prices = vec![100.0, 101.0, 102.0, 103.0];
+        let mfe = peak_favorable_move(&prices, 0, 3).unwrap();
+        assert_eq!(-1.0, mfe);
+        assert!(mfe <= 0.0);
+    }
+
+    #[test]
+    fn valley_favorable_move_nonpositive_when_no_rise() {
+        // window [104.0, 103.0, 102.0], max 104.0 -> 104.0 - 105.0 = -1.0 (returned, not floored)
+        let prices = vec![105.0, 104.0, 103.0, 102.0];
+        let mfe = valley_favorable_move(&prices, 0, 3).unwrap();
+        assert_eq!(-1.0, mfe);
+        assert!(mfe <= 0.0);
+    }
+
+    #[test]
+    fn favorable_move_inclusive_window_boundary() {
+        // valley: max 20.0 sits exactly at index + period = 3 (captured); 99.0 at +1 is excluded.
+        let prices = vec![10.0, 1.0, 1.0, 20.0, 99.0];
+        assert_eq!(10.0, valley_favorable_move(&prices, 0, 3).unwrap());
+        // peak: min 30.0 sits exactly at index + period = 3 (captured); 1.0 at +1 is excluded.
+        let prices = vec![50.0, 99.0, 99.0, 30.0, 1.0];
+        assert_eq!(20.0, peak_favorable_move(&prices, 0, 3).unwrap());
+    }
+
+    #[test]
+    fn favorable_move_single_bar_window() {
+        // period == 1: a single-bar forward window.
+        assert_eq!(10.0, peak_favorable_move(&[100.0, 90.0], 0, 1).unwrap());
+        assert_eq!(10.0, valley_favorable_move(&[100.0, 110.0], 0, 1).unwrap());
+    }
+
+    #[test]
+    fn favorable_move_errors_on_window_past_end() {
+        let prices = vec![100.0, 101.0, 102.0];
+        // window runs past the end
+        assert!(matches!(
+            peak_favorable_move(&prices, 1, 3),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+        assert!(matches!(
+            valley_favorable_move(&prices, 1, 3),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+        // index itself out of range
+        assert!(matches!(
+            peak_favorable_move(&prices, 5, 1),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+        assert!(matches!(
+            valley_favorable_move(&prices, 5, 1),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+    }
+
+    #[test]
+    fn favorable_move_errors_on_zero_period() {
+        let prices = vec![100.0, 101.0, 102.0];
+        assert!(matches!(
+            peak_favorable_move(&prices, 0, 0),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+        assert!(matches!(
+            valley_favorable_move(&prices, 0, 0),
+            Err(crate::TechnicalIndicatorError::InvalidPeriod { .. })
+        ));
+    }
+
+    #[test]
+    fn favorable_move_errors_on_empty() {
+        assert!(matches!(
+            peak_favorable_move(&[], 0, 3),
+            Err(crate::TechnicalIndicatorError::EmptyData { .. })
+        ));
+        assert!(matches!(
+            valley_favorable_move(&[], 0, 3),
+            Err(crate::TechnicalIndicatorError::EmptyData { .. })
+        ));
+    }
+
+    #[test]
+    fn favorable_move_generic_over_series() {
+        // Works on any f64 series, not just closes (here: a volume series).
+        let volume = vec![1000.0, 1200.0, 900.0, 1100.0];
+        assert_eq!(200.0, valley_favorable_move(&volume, 0, 3).unwrap());
     }
 }


### PR DESCRIPTION
## Summary
Adds two additive, policy-free public functions to `src/chart_trends.rs`, alongside `peaks`/`valleys` (Slice 1.1):

- `peak_favorable_move(prices, index, period) -> Result<f64>` → `prices[index] - min(window)`
- `valley_favorable_move(prices, index, period) -> Result<f64>` → `max(window) - prices[index]`

where `window = prices[index + 1 ..= index + period]` (the forward window, inclusive). Each is the per-target **maximum favorable excursion (MFE)** over a forward window of `period` bars after a reference `index` — the magnitude the (not-yet-built) engine's peaks/valleys detection will score against. The raw **signed** `f64` is returned (not floored at zero; `<= 0` is the caller's problem) and the functions are **generic over the series** (never hardcode close/high/low). The library stays policy-free.

> Stacked on #69 — base is `docs/polish-and-2-0-plan`. Will retarget to `main` once #69 merges.

## Scope
- **Changed:** `src/chart_trends.rs` — two new `pub fn`s inserted after `valleys`; one shared private helper `assert_favorable_window`; module-level "Included Functions" index updated; 10 named acceptance tests + doc-tests added.
- **Changed:** `CHANGELOG.md` — one `Added` bullet under `## [Unreleased]`.
- **Intentionally NOT changed:** `peaks`/`valleys` or any other module; the `TechnicalIndicatorError` enum (no new variant — it's frozen until 2.0); `Cargo.toml` version (Unreleased accumulates). Out of scope by design: detect-then-measure composites, engine policy (`N = 2*period`, dropping past-end / `<= 0` targets), the `closest_neighbor` parameter.

## Compatibility
Purely additive. No existing function, signature, semantic, output ordering, or error-variant behavior changes. Validation reuses existing variants only:
- empty `prices` → `EmptyData` (via existing `assert_non_empty`)
- `period == 0` → `InvalidPeriod`
- `index + period >= len` → `InvalidPeriod` (underflow-safe: no subtraction; `checked_add` for the window-bounds check)

Reuses `basic_indicators::single::{min, max}` as `chart_trends` already does.

## Validation
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — zero warnings
- `cargo test` — full suite green; 10 new unit tests + 2 new doc-tests pass
- `cargo doc --no-deps` — builds clean (new intra-doc links resolve)
- `cargo +1.81 build` — MSRV build passes (`checked_add` / `..=` / inline `format!` all ≥1.81-safe)

## Benchmarks
N/A — new leaf functions on the public surface; no change to any existing hot path.

## Changelog
```
- Added `chart_trends::peak_favorable_move` and `chart_trends::valley_favorable_move`: the per-target maximum favorable excursion (MFE) over a forward window of `period` bars after a reference index. Peak measures the entry-to-window-minimum drop; valley measures the window-maximum-minus-entry rise. Returns the raw signed `f64` (not floored at zero) and is generic over the series — the library stays policy-free. Reuses `basic_indicators::single::{min, max}` and validates via a shared underflow-safe window guard reusing `EmptyData` / `InvalidPeriod`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)