### PR TITLE
chore: cut 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-18
+
 ### Added
 - Added `docs/2_0_PLAN.md` capturing the deprecated-function inventory (six momentum + one volatility function), the cross-repo impact analysis for the Python/JS bindings, the `#[non_exhaustive]` migration plan, and a nine-site NaN/inf audit classified into bug-fix / documented-behavior / 2.0-breaking-validation-change. Nothing in the plan is executed yet — it is the staging area for the 2.0 cut.
 - Added a crate-level `## Errors` section to `src/lib.rs` listing every `TechnicalIndicatorError` variant with a one-line meaning. Renders in `cargo doc` and docs.rs.
@@ -55,6 +57,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Cargo.lock` is now gitignored, matching the Cargo convention for library crates. Policy documented in `CONTRIBUTING.md`.
 - `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` now assign to `@ChironMind`.
 - Restricted the published crate to library sources and user-facing docs via a `Cargo.toml` `include` allow-list (`/src`, `/examples`, `/README.md`, `/CHANGELOG.md`, `/LICENSE*`, `/Cargo.toml`), replacing the previous `exclude` list. Internal planning docs (`docs/`, root `plan.md` / `RELEASE_*.md`), `tests/`, and repo-meta files (`AGENTS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `ai-policy.yaml`, `.gitignore`) no longer ship to crates.io. Added `/plan.md` and `/RELEASE_*.md` to `.gitignore`.
+
+### Agent Notes
+- `breaking_change`: no
+- `public_api_change`: yes (additive — `chart_trends::peak_favorable_move`, `chart_trends::valley_favorable_move`, and `Display` impls on the `src/types.rs` public types)
+- `error_variant_change`: none
+- `indicator_semantics_change`: yes (bug-fixes change `chart_trends::peaks`/`valleys` output on the index-0 and retained-extremum cases; `single::aroon_up`/`aroon_down`/`stochastic_oscillator` now return `NaN` instead of panicking on all-NaN input — see Fixed)
+- `warmup_or_output_order_change`: none
 
 ## [1.2.2] - 2026-04-01
 
@@ -165,8 +174,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Historical note
 Pre-rebrand RustTI release history is documented in [`docs/CHANGELOG_RUSTTI_LEGACY.md`](docs/CHANGELOG_RUSTTI_LEGACY.md). Legacy entries use explicit `rustti-v*` tag links to avoid ambiguity with Centaur releases.
 
-[Unreleased]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/centaur-v1.2.2...HEAD
-[1.2.2]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/centaur-v1.2.1...centaur-v1.2.2
-[1.2.1]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/centaur-v1.2.0...centaur-v1.2.1
-[1.2.0]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/releases/tag/centaur-v1.2.0
-[1.0.0]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/releases/tag/centaur-v1.0.0
+[Unreleased]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/v1.2.2...v1.3.0
+[1.2.2]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/releases/tag/v1.2.0
+[1.0.0]: https://github.com/chironmind/CentaurTechnicalIndicators-Rust/releases/tag/v1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaur_technical_indicators"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["ChironMind"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo add centaur_technical_indicators
 ```
 Or, manually in your `Cargo.toml`:
 ```toml
-centaur_technical_indicators = "1.2.2"
+centaur_technical_indicators = "1.3.0"
 ```
 
 **2. Calculate your first indicator:**
@@ -314,10 +314,11 @@ Centaur Technical Indicators is the continuation of `RustTI` under a new name. T
 
 ## 📰 Release Notes
 
-**Latest (v1.2.2):**
-- Fixed `relative_strength_index` producing incorrect values due to zero-entry handling in internal gain/loss helper
-- Removed fragile indicator registry files and redundant AI onboarding docs in favor of `AGENTS.md`
-- CI jobs now run in parallel; simplified PR template
+**Latest (v1.3.0):**
+- Added maximum favorable excursion (MFE) primitives: `chart_trends::peak_favorable_move` and `valley_favorable_move`
+- Fixed `chart_trends::peaks` / `valleys` correctness bugs (spurious or dropped extrema around index 0 and after monotonic runs)
+- Hardened library functions against all-NaN input that previously panicked
+- Implemented `Display` on all public types; added per-category examples; declared MSRV 1.81
 
 [Human friendly changelog →](https://github.com/ChironMind/CentaurTechnicalIndicators-Rust/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
## Summary
Release-mechanics cut for 1.3.0 (final batch, after batches 1–7 merged). No source changes.
- Bump `Cargo.toml` `version` 1.2.2 → 1.3.0.
- Freeze `## [Unreleased]` into `## [1.3.0] - 2026-06-18`, leaving a fresh empty Unreleased.
- Add the 1.3.0 `### Agent Notes` block.
- Repoint CHANGELOG compare-links from the broken `centaur-v*` prefix to the repo's actual bare `v*` tags (and add `[1.3.0]`).

## Compatibility
- `breaking_change`: no
- `public_api_change`: yes, additive only — `chart_trends::peak_favorable_move`, `chart_trends::valley_favorable_move`, and `Display` impls on the `src/types.rs` public types.
- `indicator_semantics_change`: **yes** — the peaks/valleys output fixes (index-0 sentinel + retained-extremum) and the all-NaN-input hardening (`aroon_up`/`aroon_down`/`stochastic_oscillator` now return `NaN` instead of panicking) landed in this cycle. See the `### Fixed` entries.
- Downstream: bumps the `crt-research-engine` `gpu-indicators` parity-test pin from `=1.2.2`; that test must be updated in lockstep (tracked separately).

## Validation
- `cargo fmt --all -- --check`: clean.
- `cargo publish --dry-run`: packages (25 files, 94 KiB compressed) and compiles as v1.3.0.
- Publish set verified clean (`cargo package --list`): only `src/`, `examples/`, `README.md`, `CHANGELOG.md`, `LICENSE-MIT`, `Cargo.toml` — no `docs/`, `tests/`, or planning files.

## Changelog
This PR is the changelog freeze itself (`[Unreleased]` → `[1.3.0]`).

## Post-merge (manual, maintainer)
- Tag, overriding the legacy RustTI tag: `git tag -f v1.3.0 && git push --force origin v1.3.0`
- `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)