### PR TITLE
docs: add 1.4.0 release plan (MAE primitives)

### DIFF
--- a/docs/1.4.0_RELEASE_PLAN.md
+++ b/docs/1.4.0_RELEASE_PLAN.md
@@ -1,0 +1,26 @@
+# Release Plan — Centaur Technical Indicators 1.4.0
+
+> Status: staging area. Nothing here is committed scope yet — this file captures
+> work deliberately deferred out of 1.3.0 so it isn't lost. Promote items into
+> batches when 1.4.0 is cut.
+
+## Candidate scope
+
+- [ ] **Maximum Adverse Excursion (MAE) primitives.** Add the adverse-move
+  counterpart to the 1.3.0 favorable-move (MFE) pair in `src/chart_trends.rs`.
+  Proposed: `peak_adverse_move` and `valley_adverse_move`, mirroring
+  `peak_favorable_move` / `valley_favorable_move` exactly — forward-window over
+  `period` bars after a reference index, raw signed `f64` (not floored at zero),
+  generic over the series, policy-free, reusing `single::{min, max}` and the
+  shared `assert_favorable_window` underflow-safe guard. Like MFE, they read
+  *future* bars, so they are measurement primitives, not real-time signals.
+
+  **Rationale:** MFE/MAE are the textbook pair. 1.3.0 ships MFE-only because its
+  sole current consumer (the GPU `gpu-indicators` parity surface) needs favorable
+  magnitudes alone — but these are public functions, and shipping the adverse
+  companion completes the excursion surface for any downstream user that scores
+  both sides of a trade. Purely additive: new `pub fn`s only, zero semver cost,
+  so it slots cleanly into a 1.4.0 minor.
+
+  **Surfacing:** add to README **Available Indicators → Chart Trends** with the
+  same lookahead caveat as MFE, and to the `chart_trends` module index.


### PR DESCRIPTION
## Summary
Add `docs/1.4.0_RELEASE_PLAN.md` as a staging area for work deferred out of 1.3.0 — primarily the Maximum Adverse Excursion (MAE) primitives (`peak_adverse_move` / `valley_adverse_move`), the symmetric companion to the 1.3.0 favorable-move (MFE) pair.

## Compatibility
None — internal planning doc only. Excluded from the published crate by the `Cargo.toml` `include` allow-list (`docs/` does not ship to crates.io).

## Validation
Docs-only; no code changes. No quality gates affected.

## Changelog
None — internal planning artifact, not a user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)