### PR TITLE
docs: make agent guidance self-contained (no workspace refs, no PII)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,69 +1,145 @@
 # AGENTS.md
 
-Guidance for coding agents working in this repository.
+Guidance for coding agents working in this repository. **This file is
+self-contained** — everything needed to work here lives in this repo (this file,
+`CLAUDE.md`, `CONTRIBUTING.md`, and the README); it depends on no external or
+workspace-level file.
 
 ## Scope
-This file applies to the entire repository.
-This is an open source repository; all contributions should be suitable for public review and distribution.
+
+Applies to the entire repository. This is a public, open-source crate
+(`centaur_technical_indicators`, published to crates.io); all contributions must be
+suitable for public review and distribution.
+
+## How work arrives
+
+**If your task is a slice brief**, it is self-contained — read it and do exactly
+that. You don't need to read the implementation plan or any project spec to execute
+it; everything required is in the brief. If you hit a real gap, **stop and ask** —
+you'll be pointed at the specific file, never told to read a whole plan. Not every
+task is a brief; for ad-hoc work, follow the standing rules below. (Reviewers are
+the exception — a plan or PR review legitimately reads the plan and spec.)
 
 ## Core contribution requirements
+
 When implementing or modifying Rust code:
 
-1. Use shared validation helpers from `src/validation.rs` for input/argument checks.
-2. Return structured `TechnicalIndicatorError` values where applicable.
-3. Document new public APIs (including behavior and parameter expectations).
+1. Use the shared validation helpers in `src/validation.rs` for input/argument checks.
+2. Return structured `TechnicalIndicatorError` values; no panics or string errors in
+   library code (`unwrap()`/`expect()` only in tests and examples).
+3. Document every `pub` item with `///` comments (behavior + parameter expectations).
 4. Add or adjust tests in the same module as the change.
-5. Do not introduce deprecated API usage in new examples or tests.
-6. Add an entry for every user-facing change in `CHANGELOG.md`.
+5. No deprecated API usage in new examples or tests.
+6. Add a `CHANGELOG.md` entry for every user-facing change (see Changelog coupling).
+7. Prefer `&[f64]` over `Vec<f64>` for input data; order imports std → external → crate-internal.
 
-## Change scope discipline
-- Keep changes minimal and focused on the requested task.
-- Do not include opportunistic refactors unless explicitly requested.
-- If you identify unrelated issues, note them separately instead of bundling them into the same change.
-- Preserve existing file organization and naming conventions unless the task requires a structural change.
+## Downstream & cross-repo impact
 
-## Backward compatibility rules
-When changing public APIs (`pub` items), preserve compatibility unless the task explicitly allows a breaking change:
+This crate is the source of truth for indicator behavior; its public API ripples to
+the Python and JS bindings, the documentation site, the tutorials and how-to guides,
+and the benchmark companion. A change to public API, semantics, output ordering, or
+warmup behavior affects all of them — call out the downstream impact in your report.
+Don't make cross-repo or architectural decisions from inside this repo; surface them
+to the maintainer.
+
+## Change-scope discipline
+
+- Smallest safe diff that solves the task; keep it focused.
+- No opportunistic refactors or "while I was here" changes — note unrelated issues
+  separately, don't bundle them.
+- Preserve existing file organization and naming unless the task requires a structural change.
+- **Stage only the files your task names; never `git add .` / `git add -A`** — this
+  repo doesn't track `Cargo.lock`, and a blanket add sweeps in generated artifacts.
+  The committed decision trail under `docs/` is the deliberate exception: plans, slice
+  briefs, `RESUME.md`, and decision records (e.g. under `docs/implementation_decisions/`
+  and `docs/technical_decisions/`) are version-controlled on purpose — commit those
+  when your task creates or updates them.
+- Never hand-edit a generated artifact or a test expectation to make a gate pass. A
+  test value that needs changing is a signal to **stop and report**.
+
+## Backward compatibility
+
+Published public APIs — treat every `pub` item as a contract:
 
 1. Do not silently change indicator semantics, output ordering, or warmup behavior.
 2. Do not remove or rename public functions, types, enums, or fields without explicit approval.
-3. Do not repurpose existing `TechnicalIndicatorError` variants in ways that break downstream matching.
-4. If behavior changes are required, document them in code docs and `CHANGELOG.md` with clear migration notes.
+3. Do not repurpose `TechnicalIndicatorError` variants in ways that break downstream matching.
+4. If a behavior change is required, document it in code docs and `CHANGELOG.md` with migration notes.
 
 ## Performance-sensitive paths
-- Treat hot-path indicator computations as performance-sensitive.
-- Avoid unnecessary allocations, cloning, and intermediate buffers in computation loops.
-- Prefer existing efficient utilities/patterns already used in similar modules.
-- If performance could change materially, run and report benchmark results for affected indicators.
+
+- Treat hot-path indicator computations as performance-sensitive: avoid unnecessary
+  allocations, cloning, and intermediate buffers in computation loops; prefer the
+  efficient patterns already used in similar modules.
+- If performance could change materially, run the relevant suites in the benchmark
+  companion repo (`CentaurTechnicalIndicators-Rust-Benchmarks`) and summarize
+  regressions/improvements in your report.
 
 ## Pre-PR quality gates (must pass)
-Run these before opening a PR:
 
-1. `cargo fmt --all -- --check` (no formatting diffs)
-2. `cargo clippy --all-targets -- -D warnings` (zero warnings/errors)
-3. `cargo test` (all tests pass)
-4. `cargo doc --no-deps` (docs build successfully, including new public APIs)
-5. Benchmark checks in the companion repo (no performance regressions for affected indicators):
-   - Clone/check out `https://github.com/chironmind/CentaurTechnicalIndicators-Rust-Benchmarks`
-   - Run the relevant benchmark suite(s) and summarize regressions/improvements in the PR
+Run these before opening a PR; paste the output into the report's Validation section:
 
-## CI implementation policy
-- Keep CI implementation dependency-light, consistent with the crate philosophy.
-- Prefer native `rustup` and `cargo` commands in workflows.
-- Do not introduce third-party GitHub Actions for Rust toolchain setup or Cargo caching unless explicitly approved by maintainers.
+1. `cargo fmt --all -- --check` — no formatting diffs.
+2. `cargo clippy --all-targets -- -D warnings` — zero warnings/errors.
+3. `cargo test` — all tests pass.
+4. `cargo doc --no-deps` — docs build, including new public APIs.
 
-## PR expectations for agents
-- Keep PRs focused and minimal.
-- Summarize what the agent changed and what was manually verified.
-- Include command output summary for the required quality gates.
-- Explicitly note the `CHANGELOG.md` entry and benchmark results from the companion benchmark repo.
+## Branch & commit conventions
 
-### Required PR summary format
-Use this structure in PR descriptions/comments:
+- Cut every branch off the latest `origin/main`; never commit directly on `main`.
+  Name branches `<type>/<kebab-slug>` with a conventional-commit type (`feat`, `fix`,
+  `chore`, `docs`, `test`, `refactor`, `perf`, `ci`) — e.g. `feat/rsi-bulk`.
+- Commit subjects use a conventional-commit prefix, under 72 characters; reference
+  issue numbers where applicable.
+- End every agent-authored commit with:
 
-1. `Summary`: what changed and why.
-2. `Scope`: files/modules touched and what was intentionally not changed.
-3. `Compatibility`: any user-facing behavior/API/error-handling impact.
-4. `Validation`: results summary for `fmt`, `clippy`, `test`, and `doc`.
-5. `Benchmarks`: affected suites and regression/improvement summary.
-6. `Changelog`: exact `CHANGELOG.md` entry added/updated.
+      Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+## Stop-and-report
+
+**Never guess or assume.** If information is missing, the task is ambiguous, or two
+implementations are plausible, **stop and ask for input** before proceeding — don't
+pick one and run. Beyond that, stop and report — never work around, paper over, or
+invent a way past — when:
+
+- a pre-PR gate fails for a reason outside your change, or a test expectation shifts
+  in a way you can't explain;
+- completing the task would require a forbidden or breaking change (public API,
+  semantics, output ordering, warmup) without explicit approval;
+- the brief or instructions conflict with the repo's actual state.
+
+Surface the blocker; do not invent a way past it.
+
+## Worktree & isolation
+
+For parallel or batched work: one task per git worktree, cut off fresh `origin/main`;
+keep concurrent tasks file-disjoint; when two touch the same files, rebase the later
+on its predecessor before merging.
+
+## Changelog coupling
+
+Every user-facing change adds a bullet under the existing `## [Unreleased]` heading in
+`CHANGELOG.md` (Keep a Changelog categories: Added / Changed / Deprecated / Removed /
+Fixed / Security); name the concrete artifact. Don't add a second `[Unreleased]`
+heading. Formatting-only or non-user-facing changes (incl. docs like this file) are
+exempt — note the exception in the PR.
+
+## CI policy
+
+Keep CI dependency-light: prefer native `rustup`/`cargo` commands; no third-party
+GitHub Actions for toolchain setup or caching without explicit approval.
+
+## PR / completion report
+
+Use this structure:
+
+1. **Summary** — what changed and why.
+2. **Scope** — files/modules touched, and what was deliberately left untouched.
+3. **Compatibility** — user-facing behavior/API/error-handling impact, or "N/A".
+4. **Validation** — pasted output of the four pre-PR gates.
+5. **Changelog** — the exact `CHANGELOG.md` entry added/updated (or "exempt — non-user-facing").
+6. **Benchmarks** — affected suites + regression/improvement summary, or "N/A".
+
+Plus, required: each named acceptance test with its pass output verbatim (incl. the
+decisive test), and anything flagged — out-of-scope issues noticed, concerns,
+blockers. Justify any deviation from the brief here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # CLAUDE.md
 
-This repository's canonical agent guidance lives in [`AGENTS.md`](./AGENTS.md) — contribution
-requirements, change-scope discipline, backward-compatibility rules, and the pre-PR quality gates.
-See it before making changes.
+Claude Code notes for this repository. **[`AGENTS.md`](./AGENTS.md) is canonical**
+for every standing convention — how work arrives, the pre-PR gates, branch/commit/PR
+conventions, change-scope discipline, stop-and-report, and changelog coupling. Read
+it before making changes; this file adds only Claude-Code specifics and does not
+repeat it.
+
+- **Never guess.** If information is missing or the task is ambiguous, stop and ask
+  for input — don't assume.
+- **Effort:** if your task is a slice brief, set the session to its `effort` with
+  `/effort <level>` before starting.
+- **Plan before auto-editing:** for non-trivial work, plan in plan mode before
+  auto-applying changes.
+- **Read-order:** your brief is self-contained — see `AGENTS.md` → "How work
+  arrives." Don't pull in the implementation plan or project spec to execute a
+  brief; if you hit a gap, stop and ask.


### PR DESCRIPTION
Makes `AGENTS.md` and `CLAUDE.md` in this repository fully self-contained — everything a coding agent needs is in-repo, with no references to any workspace-level file and no machine or personal paths (so a cloner gets working guidance, and nothing leaks).

- Self-contained header, plus a never-guess rule: missing info or ambiguity means stop and ask.
- Read-order: an implementer works only from its self-contained slice brief.
- CTI libraries share a harmonized structure; companion and site repos use a trimmed self-contained form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
